### PR TITLE
Multiplayer consent screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a custom build of osu!lazer that includes a custom mod for Buttplug.io s
 
 To use, make sure intiface is running and you have a device connected, then enable the `Toy` mod in mods menu, `and your motor is revved and VROOOM VROOOM AWOOOOOOGAHHH HUFFA HUFFA WAOOOOOOOOO`
 
+(Disclaimer: Please do not use this mod while accessing public game servers with unsuspecting players. This is meant for single player and/or matched play with consenting participants. Thank you!)
+
 ## Settings
 
 If you are running Intiface on a different port or want to use a different address entirely, you can change the address in Settings under Toy > Intiface. If the game is already connected to an existing Intiface, you will need to restart for the change to take effect.

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -142,6 +142,7 @@ namespace osu.Game.Configuration
 
             // toy stuff
             Set(OsuSetting.IntifaceAddress, "ws://127.0.0.1:12345");
+            Set(OsuSetting.MultiplayerConsentAcknowledged, false);
         }
 
         public OsuConfigManager(Storage storage)
@@ -272,6 +273,7 @@ namespace osu.Game.Configuration
         AutomaticallyDownloadWhenSpectating,
 
         // toy stuff
-        IntifaceAddress
+        IntifaceAddress,
+        MultiplayerConsentAcknowledged
     }
 }

--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -8,16 +9,20 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Logging;
+using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Multi.Components;
 using osu.Game.Screens.Multi.Lounge;
@@ -33,6 +38,9 @@ namespace osu.Game.Screens.Multi
     public class Multiplayer : OsuScreen
     {
         public override bool CursorVisible => (screenStack.CurrentScreen as IMultiplayerSubScreen)?.CursorVisible ?? true;
+
+        [Resolved]
+        protected NotificationOverlay Notifications { get; private set; }
 
         // this is required due to PlayerLoader eventually being pushed to the main stack
         // while leases may be taken out by a subscreen.
@@ -72,6 +80,7 @@ namespace osu.Game.Screens.Multi
 
         public Multiplayer()
         {
+            // Notifications = new NotificationOverlay();
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             RelativeSizeAxes = Axes.Both;
@@ -157,6 +166,12 @@ namespace osu.Game.Screens.Multi
 
             if (idleTracker != null)
                 isIdle.BindTo(idleTracker.IsIdle);
+
+            Notifications?.Post(new SimpleNotification
+            {
+                Text = $"Disclaimer: Please do not use this mod while accessing public game servers with unsuspecting players. \n" +
+                       $"This is meant for single player and/or matched play with consenting participants. Thank you!"
+            });
         }
 
         private void onlineStateChanged(ValueChangedEvent<APIState> state) => Schedule(() =>

--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -9,20 +8,17 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Logging;
-using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
-using osu.Game.Graphics;
+using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Overlays;
-using osu.Game.Overlays.Notifications;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Multi.Components;
 using osu.Game.Screens.Multi.Lounge;
@@ -38,9 +34,6 @@ namespace osu.Game.Screens.Multi
     public class Multiplayer : OsuScreen
     {
         public override bool CursorVisible => (screenStack.CurrentScreen as IMultiplayerSubScreen)?.CursorVisible ?? true;
-
-        [Resolved]
-        protected NotificationOverlay Notifications { get; private set; }
 
         // this is required due to PlayerLoader eventually being pushed to the main stack
         // while leases may be taken out by a subscreen.
@@ -75,12 +68,14 @@ namespace osu.Game.Screens.Multi
         [Resolved(CanBeNull = true)]
         private OsuLogo logo { get; set; }
 
+        [Resolved]
+        private OsuConfigManager config { get; set; }
+
         private readonly Drawable header;
         private readonly Drawable headerBackground;
 
         public Multiplayer()
         {
-            // Notifications = new NotificationOverlay();
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             RelativeSizeAxes = Axes.Both;
@@ -166,12 +161,6 @@ namespace osu.Game.Screens.Multi
 
             if (idleTracker != null)
                 isIdle.BindTo(idleTracker.IsIdle);
-
-            Notifications?.Post(new SimpleNotification
-            {
-                Text = $"Disclaimer: Please do not use this mod while accessing public game servers with unsuspecting players. \n" +
-                       $"This is meant for single player and/or matched play with consenting participants. Thank you!"
-            });
         }
 
         private void onlineStateChanged(ValueChangedEvent<APIState> state) => Schedule(() =>
@@ -243,6 +232,9 @@ namespace osu.Game.Screens.Multi
         {
             this.FadeIn();
             waves.Show();
+
+            if (config.Get<bool>(OsuSetting.MultiplayerConsentAcknowledged) != true)
+                this.Push(new MultiplayerConsent());
 
             beginHandlingTrack();
         }

--- a/osu.Game/Screens/Multi/MultiplayerConsent.cs
+++ b/osu.Game/Screens/Multi/MultiplayerConsent.cs
@@ -1,0 +1,96 @@
+﻿using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Screens;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osuTK;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace osu.Game.Screens.Multi
+{
+    class MultiplayerConsent : OsuScreen
+    {
+        [Resolved]
+        private MusicController music { get; set; }
+
+        [Resolved]
+        private OsuConfigManager config { get; set; }
+
+        public override bool AllowBackButton => false;
+        public override bool HideOverlaysOnEnter => true;
+
+        public MultiplayerConsent()
+        {
+            LinkFlowContainer textFlow;
+
+            InternalChildren = new Drawable[]
+            {
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Spacing = new Vector2(0, 20),
+                    Children = new Drawable[]
+                    {
+                        textFlow = new LinkFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            TextAnchor = Anchor.TopCentre,
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Spacing = new Vector2(0, 2)
+                        },
+                        new TriangleButton {
+                            Text = "I Understand",
+                            Width = 200,
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Action = () =>
+                            {
+                                config.Set(OsuSetting.MultiplayerConsentAcknowledged, true);
+                                this.Exit();
+                            }
+                        }
+                    }
+                }
+            };
+
+            textFlow.AddText("Before you start...", t => t.Font = t.Font.With(Typeface.Torus, 30, FontWeight.Bold));
+            textFlow.NewParagraph();
+
+            textFlow.AddText(
+                "Please do not use this mod while accessing public game servers with unsuspecting players.\n" +
+                "This is meant for single player and/or matched play with consenting participants. Thank you!",
+                t => t.Font = t.Font.With(Typeface.Torus, 24, FontWeight.SemiBold)
+            );
+        }
+
+        public override void OnEntering(IScreen last)
+        {
+            base.OnEntering(last);
+            this.FadeIn(250);
+            Background.FadeColour(Colour4.Black, 250);
+            music?.Stop();
+        }
+
+        public override bool OnExiting(IScreen next)
+        {
+            music?.EnsurePlayingSomething();
+            this.FadeOut(250);
+
+            return base.OnExiting(next);
+        }
+    }
+}


### PR DESCRIPTION
Instead of a notification when the user opens multiplayer (which should have gone in `OnEntered` imo), the first time the user opens the multiplayer screen they will see this message:

![image](https://user-images.githubusercontent.com/2646487/104368883-b0c96080-54ea-11eb-8f93-a0e76d1020ef.png)

The music will also stop to grab their attention. Once they click "I Understand", they won't see the message again.